### PR TITLE
Wifi 792 rf radio profile

### DIFF
--- a/portal-services/src/main/resources/portal-services-openapi.yaml
+++ b/portal-services/src/main/resources/portal-services-openapi.yaml
@@ -918,6 +918,7 @@ components:
         - radius
         - captive_portal
         - mesh
+        - rf
 
     Profile:
       description: Each AccessPoint refers to at most one profile of type equipment_ap. Each ApNetworkConfiguration (equipment_ap) profile refers to 0-N SSID profiles via its childProfileIds property. Each SSID profile refers to at most 1 Captive Portal Profile and 1 Bonjour Gateway Profile and 1 RADIUS Service Profile via its childProfileIds property. Each Captive Portal Profile refers to at most 1 RADIUS Service Profile via its childProfileIds property.
@@ -967,6 +968,7 @@ components:
           - MeshGroup
           - RadiusProfile
           - SsidConfiguration
+          - RfConfiguration
       required: 
         - model_type
 
@@ -978,6 +980,7 @@ components:
         - $ref: '#/components/schemas/MeshGroup'
         - $ref: '#/components/schemas/RadiusProfile'
         - $ref: '#/components/schemas/SsidConfiguration'
+        - $ref: '#/components/schemas/RfConfiguration'
       discriminator:
         propertyName: model_type
         
@@ -1454,6 +1457,55 @@ components:
           type: integer
           format: int32
         
+    RfConfiguration:
+      description: Properties for the RF ConfigurationProfile
+      allOf:
+      - $ref: '#/components/schemas/ProfileDetails'
+      - type: object
+        properties:
+          rfConfigMap:
+             $ref: '#/components/schemas/RfConfigMap'
+    
+    RfConfigMap:
+      properties:
+        is2dot4GHz:
+          $ref: '#/components/schemas/RfElementConfiguration'
+        is5GHz:
+          $ref: '#/components/schemas/RfElementConfiguration'
+        is5GHzU:
+          $ref: '#/components/schemas/RfElementConfiguration'
+        is5GHzL:
+          $ref: '#/components/schemas/RfElementConfiguration'
+    
+    RfElementConfiguration:
+      properties:
+        model_type:
+          type: string
+          enum:
+          - RfElementConfiguration
+        rf:
+          type: string
+        beaconInterval:
+          type: integer
+          format: int32
+        forceScanDuringVoice:
+          $ref: '#/components/schemas/StateSetting'
+        rtsCtsThreshold:
+          type: integer
+          format: int32
+        channelBandwidth:
+          $ref: '#/components/schemas/ChannelBandwidth'
+        mimoMode:
+          $ref: '#/components/schemas/MimoMode'
+        maxNumClients:
+          type: integer
+          format: int32
+        multicastRate:
+          $ref: '#/components/schemas/MulticastRate'
+        autoChannelSelection:
+          type: boolean
+        activeScanSettings:
+          $ref: '#/components/schemas/ActiveScanSettings'   
     
 
     SsidConfiguration:

--- a/profile-models/src/main/java/com/telecominfraproject/wlan/profile/models/ProfileType.java
+++ b/profile-models/src/main/java/com/telecominfraproject/wlan/profile/models/ProfileType.java
@@ -56,6 +56,7 @@ public class ProfileType implements EnumWithId {
     captive_portal = new ProfileType(6, "captive_portal"),
     mesh = new ProfileType(7, "mesh"),
     metrics = new ProfileType(8,"metrics"),
+    rf = new ProfileType(9, "rf"),
     UNSUPPORTED = new ProfileType(-1, "UNSUPPORTED");
     
     static {

--- a/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfConfiguration.java
+++ b/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfConfiguration.java
@@ -1,0 +1,67 @@
+package com.telecominfraproject.wlan.profile.rf.models;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.telecominfraproject.wlan.core.model.equipment.PushableConfiguration;
+import com.telecominfraproject.wlan.core.model.equipment.RadioType;
+import com.telecominfraproject.wlan.profile.models.ProfileDetails;
+import com.telecominfraproject.wlan.profile.models.ProfileType;
+
+public class RfConfiguration extends ProfileDetails implements PushableConfiguration<RfConfiguration>{
+
+	private static final long serialVersionUID = -8842969359594832744L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(RfConfiguration.class);
+    
+    // Map of RfConfigs for each RadioType
+    private Map<RadioType, RfElementConfiguration> rfConfigMap;
+    
+    private RfConfiguration() {
+    	super();
+    	rfConfigMap = new EnumMap<>(RadioType.class);
+    	rfConfigMap.put(RadioType.is2dot4GHz, RfElementConfiguration.createWithDefaults(RadioType.is2dot4GHz));
+    	rfConfigMap.put(RadioType.is5GHz, RfElementConfiguration.createWithDefaults(RadioType.is5GHz));
+    	rfConfigMap.put(RadioType.is5GHzL, RfElementConfiguration.createWithDefaults(RadioType.is5GHzL));
+    	rfConfigMap.put(RadioType.is5GHzU, RfElementConfiguration.createWithDefaults(RadioType.is5GHzU));
+    }
+    
+    public static RfConfiguration createWithDefaults() {
+        RfConfiguration ret = new RfConfiguration();  	
+    	return ret;
+    }
+    
+    // Get RfConfig for all RadioTypes
+	public Map<RadioType, RfElementConfiguration> getRfConfigMap() {
+		return rfConfigMap;
+	}
+
+	public void setRfConfigMap(Map<RadioType, RfElementConfiguration> rfConfigMap) {
+		this.rfConfigMap = rfConfigMap;
+	}
+	
+	// Get RfConfig for specific RadioType
+	public RfElementConfiguration getRfConfig(RadioType radioType) {
+		if (rfConfigMap == null)
+			return null;
+		return rfConfigMap.get(radioType);
+	}
+	
+	public void setRfConfig(RadioType radioType, RfElementConfiguration rfConfig) {
+		this.rfConfigMap.put(radioType, rfConfig);
+	}
+	
+	@Override
+	public boolean needsToBeUpdatedOnDevice(RfConfiguration previousVersion) {
+		return !equals(previousVersion);
+	}
+
+	@Override
+	public ProfileType getProfileType() {
+		return ProfileType.rf;
+	}
+
+}

--- a/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfElementConfiguration.java
+++ b/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfElementConfiguration.java
@@ -1,19 +1,16 @@
 package com.telecominfraproject.wlan.profile.rf.models;
 
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.telecominfraproject.wlan.core.model.equipment.AutoOrManualValue;
 import com.telecominfraproject.wlan.core.model.equipment.ChannelBandwidth;
-import com.telecominfraproject.wlan.core.model.equipment.ChannelHopSettings;
-import com.telecominfraproject.wlan.core.model.equipment.RadioBestApSettings;
 import com.telecominfraproject.wlan.core.model.equipment.RadioType;
 import com.telecominfraproject.wlan.core.model.json.BaseJsonModel;
 import com.telecominfraproject.wlan.equipment.models.ActiveScanSettings;
-import com.telecominfraproject.wlan.equipment.models.ManagementRate;
 import com.telecominfraproject.wlan.equipment.models.MimoMode;
 import com.telecominfraproject.wlan.equipment.models.MulticastRate;
-import com.telecominfraproject.wlan.equipment.models.NeighbouringAPListConfiguration;
 import com.telecominfraproject.wlan.equipment.models.StateSetting;
 
 public class RfElementConfiguration extends BaseJsonModel {
@@ -22,10 +19,12 @@ public class RfElementConfiguration extends BaseJsonModel {
 	
     private static final Logger LOG = LoggerFactory.getLogger(RfElementConfiguration.class);
     
-    public final static int MIN_BG_RADIO_CELL_SIZE = -80;
-	public final static int MIN_AC_RADIO_CELL_SIZE = -80;
-	public final static int DEFAULT_RX_CELL_SIZE_DB = -90;
-	public final static int DEFAULT_EIRP_TX_POWER = 18;
+//  private final static int MIN_TWOFOURG_RADIO_CELL_SIZE = -80;
+//	private final static int MIN_FIVEG_RADIO_CELL_SIZE = -80;
+//	private final static int MIN_FIVEGUPPER_RADIO_CELL_SIZE = -80;
+//	private final static int MIN_FIVEGLOWER_RADIO_CELL_SIZE = -80;
+//	public final static int DEFAULT_RX_CELL_SIZE_DB = -90;
+//	public final static int DEFAULT_EIRP_TX_POWER = 18;
 	public final static int DEFAULT_BEACON_INTERVAL = 100;
 	
     // Parameters for each RadioType
@@ -40,8 +39,8 @@ public class RfElementConfiguration extends BaseJsonModel {
     private boolean autoChannelSelection;
     private ActiveScanSettings activeScanSettings;
 //    
-//    private ManagementRate managementRate;
-//    private AutoOrManualValue rxCellSizeDb;
+//  private ManagementRate managementRate;
+//  private AutoOrManualValue rxCellSizeDb;
 //	private AutoOrManualValue probeResponseThresholdDb;
 //	private AutoOrManualValue clientDisconnectThresholdDb;
 //	private AutoOrManualValue eirpTxPower;
@@ -49,8 +48,8 @@ public class RfElementConfiguration extends BaseJsonModel {
 //	private NeighbouringAPListConfiguration neighbouringListApConfig;
 //	private Integer minAutoCellSize;
 //	private Boolean perimeterDetectionEnabled;
-//    private ChannelHopSettings channelHopSettings;
-//    private RadioBestApSettings bestApSettings;
+//  private ChannelHopSettings channelHopSettings;
+//  private RadioBestApSettings bestApSettings;
     
     private RfElementConfiguration() {
     	long timestamp = System.currentTimeMillis();
@@ -76,7 +75,7 @@ public class RfElementConfiguration extends BaseJsonModel {
     
     public static RfElementConfiguration createWithDefaults(RadioType radioType) {
         RfElementConfiguration ret = new RfElementConfiguration();  
-//        ret.setBestApSettings(RadioBestApSettings.createWithDefaults(radioType));
+//      ret.setBestApSettings(RadioBestApSettings.createWithDefaults(radioType));
         if (radioType == RadioType.is5GHz || radioType == RadioType.is5GHzL || radioType == RadioType.is5GHzU) {
     		ret.setChannelBandwidth(ChannelBandwidth.is80MHz);
 //    		ret.setMinAutoCellSize(MIN_AC_RADIO_CELL_SIZE);
@@ -266,129 +265,29 @@ public class RfElementConfiguration extends BaseJsonModel {
 	
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((activeScanSettings == null) ? 0 : activeScanSettings.hashCode());
-		result = prime * result + (autoChannelSelection ? 1231 : 1237);
-		result = prime * result + ((beaconInterval == null) ? 0 : beaconInterval.hashCode());
-//		result = prime * result + ((bestApEnabled == null) ? 0 : bestApEnabled.hashCode());
-//		result = prime * result + ((bestApSettings == null) ? 0 : bestApSettings.hashCode());
-		result = prime * result + ((channelBandwidth == null) ? 0 : channelBandwidth.hashCode());
-//		result = prime * result + ((channelHopSettings == null) ? 0 : channelHopSettings.hashCode());
-//		result = prime * result + ((clientDisconnectThresholdDb == null) ? 0 : clientDisconnectThresholdDb.hashCode());
-//		result = prime * result + ((eirpTxPower == null) ? 0 : eirpTxPower.hashCode());
-		result = prime * result + ((forceScanDuringVoice == null) ? 0 : forceScanDuringVoice.hashCode());
-//		result = prime * result + ((managementRate == null) ? 0 : managementRate.hashCode());
-		result = prime * result + ((maxNumClients == null) ? 0 : maxNumClients.hashCode());
-		result = prime * result + ((mimoMode == null) ? 0 : mimoMode.hashCode());
-//		result = prime * result + ((minAutoCellSize == null) ? 0 : minAutoCellSize.hashCode());
-		result = prime * result + ((multicastRate == null) ? 0 : multicastRate.hashCode());
-//		result = prime * result + ((neighbouringListApConfig == null) ? 0 : neighbouringListApConfig.hashCode());
-//		result = prime * result + ((perimeterDetectionEnabled == null) ? 0 : perimeterDetectionEnabled.hashCode());
-//		result = prime * result + ((probeResponseThresholdDb == null) ? 0 : probeResponseThresholdDb.hashCode());
-		result = prime * result + ((rf == null) ? 0 : rf.hashCode());
-		result = prime * result + ((rtsCtsThreshold == null) ? 0 : rtsCtsThreshold.hashCode());
-//		result = prime * result + ((rxCellSizeDb == null) ? 0 : rxCellSizeDb.hashCode());
-		return result;
+		return Objects.hash(rf, beaconInterval, forceScanDuringVoice, rtsCtsThreshold, channelBandwidth,
+				mimoMode, maxNumClients, multicastRate, autoChannelSelection, activeScanSettings);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
-		if (obj == null)
+		if (!super.equals(obj))
 			return false;
-		if (getClass() != obj.getClass())
+		if (!(obj instanceof RfElementConfiguration))
 			return false;
 		RfElementConfiguration other = (RfElementConfiguration) obj;
-		if (activeScanSettings == null) {
-			if (other.activeScanSettings != null)
-				return false;
-		} else if (!activeScanSettings.equals(other.activeScanSettings))
-			return false;
-		if (autoChannelSelection != other.autoChannelSelection)
-			return false;
-		if (beaconInterval == null) {
-			if (other.beaconInterval != null)
-				return false;
-		} else if (!beaconInterval.equals(other.beaconInterval))
-			return false;
-//		if (bestApEnabled == null) {
-//			if (other.bestApEnabled != null)
-//				return false;
-//		} else if (!bestApEnabled.equals(other.bestApEnabled))
-//			return false;
-//		if (bestApSettings == null) {
-//			if (other.bestApSettings != null)
-//				return false;
-//		} else if (!bestApSettings.equals(other.bestApSettings))
-//			return false;
-		if (channelBandwidth != other.channelBandwidth)
-			return false;
-//		if (channelHopSettings == null) {
-//			if (other.channelHopSettings != null)
-//				return false;
-//		} else if (!channelHopSettings.equals(other.channelHopSettings))
-//			return false;
-//		if (clientDisconnectThresholdDb == null) {
-//			if (other.clientDisconnectThresholdDb != null)
-//				return false;
-//		} else if (!clientDisconnectThresholdDb.equals(other.clientDisconnectThresholdDb))
-//			return false;
-//		if (eirpTxPower == null) {
-//			if (other.eirpTxPower != null)
-//				return false;
-//		} else if (!eirpTxPower.equals(other.eirpTxPower))
-//			return false;
-		if (forceScanDuringVoice != other.forceScanDuringVoice)
-			return false;
-//		if (managementRate != other.managementRate)
-//			return false;
-		if (maxNumClients == null) {
-			if (other.maxNumClients != null)
-				return false;
-		} else if (!maxNumClients.equals(other.maxNumClients))
-			return false;
-		if (mimoMode != other.mimoMode)
-			return false;
-//		if (minAutoCellSize == null) {
-//			if (other.minAutoCellSize != null)
-//				return false;
-//		} else if (!minAutoCellSize.equals(other.minAutoCellSize))
-//			return false;
-		if (multicastRate != other.multicastRate)
-			return false;
-//		if (neighbouringListApConfig == null) {
-//			if (other.neighbouringListApConfig != null)
-//				return false;
-//		} else if (!neighbouringListApConfig.equals(other.neighbouringListApConfig))
-//			return false;
-//		if (perimeterDetectionEnabled == null) {
-//			if (other.perimeterDetectionEnabled != null)
-//				return false;
-//		} else if (!perimeterDetectionEnabled.equals(other.perimeterDetectionEnabled))
-//			return false;
-//		if (probeResponseThresholdDb == null) {
-//			if (other.probeResponseThresholdDb != null)
-//				return false;
-//		} else if (!probeResponseThresholdDb.equals(other.probeResponseThresholdDb))
-//			return false;
-		if (rf == null) {
-			if (other.rf != null)
-				return false;
-		} else if (!rf.equals(other.rf))
-			return false;
-		if (rtsCtsThreshold == null) {
-			if (other.rtsCtsThreshold != null)
-				return false;
-		} else if (!rtsCtsThreshold.equals(other.rtsCtsThreshold))
-			return false;
-//		if (rxCellSizeDb == null) {
-//			if (other.rxCellSizeDb != null)
-//				return false;
-//		} else if (!rxCellSizeDb.equals(other.rxCellSizeDb))
-//			return false;
-		return true;
+		return Objects.equals(rf, other.rf)
+				&& Objects.equals(beaconInterval, other.beaconInterval)
+				&& Objects.equals(forceScanDuringVoice, other.forceScanDuringVoice)
+				&& Objects.equals(rtsCtsThreshold, other.rtsCtsThreshold)
+				&& Objects.equals(channelBandwidth, other.channelBandwidth)
+				&& Objects.equals(mimoMode, other.mimoMode)
+				&& Objects.equals(maxNumClients, other.maxNumClients)
+				&& Objects.equals(multicastRate, other.multicastRate)
+				&& Objects.equals(autoChannelSelection,  other.autoChannelSelection)
+				&& Objects.equals(activeScanSettings, other.activeScanSettings);
 	}
 	
 	@Override
@@ -398,9 +297,8 @@ public class RfElementConfiguration extends BaseJsonModel {
 		}
 		if (StateSetting.isUnsupported(forceScanDuringVoice) || ChannelBandwidth.isUnsupported(channelBandwidth)
 				|| MimoMode.isUnsupported(mimoMode) || MulticastRate.isUnsupported(multicastRate) 
-//				|| ManagementRate.isUnsupported(managementRate)
 				|| ActiveScanSettings.hasUnsupportedValue(activeScanSettings) 
-//				|| AutoOrManualValue.hasUnsupportedValue(rxCellSizeDb) 
+//				|| AutoOrManualValue.hasUnsupportedValue(rxCellSizeDb) || ManagementRate.isUnsupported(managementRate)
 //				|| AutoOrManualValue.hasUnsupportedValue(probeResponseThresholdDb) || AutoOrManualValue.hasUnsupportedValue(clientDisconnectThresholdDb) 
 //				|| AutoOrManualValue.hasUnsupportedValue(eirpTxPower) || NeighbouringAPListConfiguration.hasUnsupportedValue(neighbouringListApConfig)
 //				|| ChannelHopSettings.hasUnsupportedValue(channelHopSettings) || RadioBestApSettings.hasUnsupportedValue(bestApSettings)

--- a/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfElementConfiguration.java
+++ b/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfElementConfiguration.java
@@ -36,7 +36,7 @@ public class RfElementConfiguration extends BaseJsonModel {
     private MimoMode mimoMode;
     private Integer maxNumClients;
     private MulticastRate multicastRate;
-    private boolean autoChannelSelection;
+//  private boolean autoChannelSelection;
     private ActiveScanSettings activeScanSettings;
 //    
 //  private ManagementRate managementRate;
@@ -60,7 +60,7 @@ public class RfElementConfiguration extends BaseJsonModel {
     	setMimoMode(MimoMode.twoByTwo);
     	setMaxNumClients(100);
     	setMulticastRate(MulticastRate.auto);
-    	setAutoChannelSelection(false);
+//    	setAutoChannelSelection(false);
     	setActiveScanSettings(ActiveScanSettings.createWithDefaults());
 //    	setManagementRate(ManagementRate.auto);
 //    	setRxCellSizeDb(AutoOrManualValue.createAutomaticInstance(DEFAULT_RX_CELL_SIZE_DB));
@@ -150,13 +150,13 @@ public class RfElementConfiguration extends BaseJsonModel {
 		this.multicastRate = multicastRate;
 	}
 
-	public boolean getAutoChannelSelection() {
-		return autoChannelSelection;
-	}
-
-	public void setAutoChannelSelection(boolean autoChannelSelection) {
-		this.autoChannelSelection = autoChannelSelection;
-	}
+//	public boolean getAutoChannelSelection() {
+//		return autoChannelSelection;
+//	}
+//
+//	public void setAutoChannelSelection(boolean autoChannelSelection) {
+//		this.autoChannelSelection = autoChannelSelection;
+//	}
 
 	public ActiveScanSettings getActiveScanSettings() {
 		return activeScanSettings;
@@ -266,7 +266,7 @@ public class RfElementConfiguration extends BaseJsonModel {
 	@Override
 	public int hashCode() {
 		return Objects.hash(rf, beaconInterval, forceScanDuringVoice, rtsCtsThreshold, channelBandwidth,
-				mimoMode, maxNumClients, multicastRate, autoChannelSelection, activeScanSettings);
+				mimoMode, maxNumClients, multicastRate, activeScanSettings);
 	}
 
 	@Override
@@ -286,7 +286,6 @@ public class RfElementConfiguration extends BaseJsonModel {
 				&& Objects.equals(mimoMode, other.mimoMode)
 				&& Objects.equals(maxNumClients, other.maxNumClients)
 				&& Objects.equals(multicastRate, other.multicastRate)
-				&& Objects.equals(autoChannelSelection,  other.autoChannelSelection)
 				&& Objects.equals(activeScanSettings, other.activeScanSettings);
 	}
 	

--- a/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfElementConfiguration.java
+++ b/profile-models/src/main/java/com/telecominfraproject/wlan/profile/rf/models/RfElementConfiguration.java
@@ -1,0 +1,413 @@
+package com.telecominfraproject.wlan.profile.rf.models;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.telecominfraproject.wlan.core.model.equipment.AutoOrManualValue;
+import com.telecominfraproject.wlan.core.model.equipment.ChannelBandwidth;
+import com.telecominfraproject.wlan.core.model.equipment.ChannelHopSettings;
+import com.telecominfraproject.wlan.core.model.equipment.RadioBestApSettings;
+import com.telecominfraproject.wlan.core.model.equipment.RadioType;
+import com.telecominfraproject.wlan.core.model.json.BaseJsonModel;
+import com.telecominfraproject.wlan.equipment.models.ActiveScanSettings;
+import com.telecominfraproject.wlan.equipment.models.ManagementRate;
+import com.telecominfraproject.wlan.equipment.models.MimoMode;
+import com.telecominfraproject.wlan.equipment.models.MulticastRate;
+import com.telecominfraproject.wlan.equipment.models.NeighbouringAPListConfiguration;
+import com.telecominfraproject.wlan.equipment.models.StateSetting;
+
+public class RfElementConfiguration extends BaseJsonModel {
+
+	private static final long serialVersionUID = 1071268246965238451L;
+	
+    private static final Logger LOG = LoggerFactory.getLogger(RfElementConfiguration.class);
+    
+    public final static int MIN_BG_RADIO_CELL_SIZE = -80;
+	public final static int MIN_AC_RADIO_CELL_SIZE = -80;
+	public final static int DEFAULT_RX_CELL_SIZE_DB = -90;
+	public final static int DEFAULT_EIRP_TX_POWER = 18;
+	public final static int DEFAULT_BEACON_INTERVAL = 100;
+	
+    // Parameters for each RadioType
+    private String rf;
+	private Integer beaconInterval; // keep this in sync with fields in RadioCfg (in protobuf)
+    private StateSetting forceScanDuringVoice;
+    private Integer rtsCtsThreshold;
+    private ChannelBandwidth channelBandwidth;
+    private MimoMode mimoMode;
+    private Integer maxNumClients;
+    private MulticastRate multicastRate;
+    private boolean autoChannelSelection;
+    private ActiveScanSettings activeScanSettings;
+//    
+//    private ManagementRate managementRate;
+//    private AutoOrManualValue rxCellSizeDb;
+//	private AutoOrManualValue probeResponseThresholdDb;
+//	private AutoOrManualValue clientDisconnectThresholdDb;
+//	private AutoOrManualValue eirpTxPower;
+//	private Boolean bestApEnabled;
+//	private NeighbouringAPListConfiguration neighbouringListApConfig;
+//	private Integer minAutoCellSize;
+//	private Boolean perimeterDetectionEnabled;
+//    private ChannelHopSettings channelHopSettings;
+//    private RadioBestApSettings bestApSettings;
+    
+    private RfElementConfiguration() {
+    	long timestamp = System.currentTimeMillis();
+    	setRf("DefaultRf-" + timestamp);
+    	setBeaconInterval(DEFAULT_BEACON_INTERVAL);
+    	setForceScanDuringVoice(StateSetting.disabled);
+    	setRtsCtsThreshold(65535);
+    	setMimoMode(MimoMode.twoByTwo);
+    	setMaxNumClients(100);
+    	setMulticastRate(MulticastRate.auto);
+    	setAutoChannelSelection(false);
+    	setActiveScanSettings(ActiveScanSettings.createWithDefaults());
+//    	setManagementRate(ManagementRate.auto);
+//    	setRxCellSizeDb(AutoOrManualValue.createAutomaticInstance(DEFAULT_RX_CELL_SIZE_DB));
+//    	setProbeResponseThresholdDb(AutoOrManualValue.createAutomaticInstance(-90));
+//    	setClientDisconnectThresholdDb(AutoOrManualValue.createAutomaticInstance(-90));
+//    	setEirpTxPower(AutoOrManualValue.createAutomaticInstance(DEFAULT_EIRP_TX_POWER));
+//    	setBestApEnabled(null);
+//    	setNeighbouringListApConfig(NeighbouringAPListConfiguration.createDefault());
+//    	setPerimeterDetectionEnabled(true);
+//    	setChannelHopSettings(ChannelHopSettings.createWithDefaults());
+    }
+    
+    public static RfElementConfiguration createWithDefaults(RadioType radioType) {
+        RfElementConfiguration ret = new RfElementConfiguration();  
+//        ret.setBestApSettings(RadioBestApSettings.createWithDefaults(radioType));
+        if (radioType == RadioType.is5GHz || radioType == RadioType.is5GHzL || radioType == RadioType.is5GHzU) {
+    		ret.setChannelBandwidth(ChannelBandwidth.is80MHz);
+//    		ret.setMinAutoCellSize(MIN_AC_RADIO_CELL_SIZE);
+        } else {
+        	ret.setChannelBandwidth(ChannelBandwidth.is20MHz);
+//        	ret.setMinAutoCellSize(MIN_BG_RADIO_CELL_SIZE);
+        }
+    	return ret;
+    }
+    
+    public String getRf() {
+		return rf;
+	}
+
+	public void setRf(String rf) {
+		this.rf = rf;
+	}
+
+	public Integer getBeaconInterval() {
+		return beaconInterval;
+	}
+
+	public void setBeaconInterval(Integer beaconInterval) {
+		this.beaconInterval = beaconInterval;
+	}
+
+	public StateSetting getForceScanDuringVoice() {
+		return forceScanDuringVoice;
+	}
+
+	public void setForceScanDuringVoice(StateSetting forceScanDuringVoice) {
+		this.forceScanDuringVoice = forceScanDuringVoice;
+	}
+
+	public Integer getRtsCtsThreshold() {
+		return rtsCtsThreshold;
+	}
+
+	public void setRtsCtsThreshold(Integer rtsCtsThreshold) {
+		this.rtsCtsThreshold = rtsCtsThreshold;
+	}
+
+	public ChannelBandwidth getChannelBandwidth() {
+		return channelBandwidth;
+	}
+
+	public void setChannelBandwidth(ChannelBandwidth channelBandwidth) {
+		this.channelBandwidth = channelBandwidth;
+	}
+
+	public MimoMode getMimoMode() {
+		return mimoMode;
+	}
+
+	public void setMimoMode(MimoMode mimoMode) {
+		this.mimoMode = mimoMode;
+	}
+
+	public Integer getMaxNumClients() {
+		return maxNumClients;
+	}
+
+	public void setMaxNumClients(Integer maxNumClients) {
+		this.maxNumClients = maxNumClients;
+	}
+
+	public MulticastRate getMulticastRate() {
+		return multicastRate;
+	}
+
+	public void setMulticastRate(MulticastRate multicastRate) {
+		this.multicastRate = multicastRate;
+	}
+
+	public boolean getAutoChannelSelection() {
+		return autoChannelSelection;
+	}
+
+	public void setAutoChannelSelection(boolean autoChannelSelection) {
+		this.autoChannelSelection = autoChannelSelection;
+	}
+
+	public ActiveScanSettings getActiveScanSettings() {
+		return activeScanSettings;
+	}
+
+	public void setActiveScanSettings(ActiveScanSettings activeScanSettings) {
+		this.activeScanSettings = activeScanSettings;
+	}
+
+//	public ManagementRate getManagementRate() {
+//		return managementRate;
+//	}
+//
+//	public void setManagementRate(ManagementRate managementRate) {
+//		this.managementRate = managementRate;
+//	}
+//
+//	public AutoOrManualValue getRxCellSizeDb() {
+//		return rxCellSizeDb;
+//	}
+//
+//	public void setRxCellSizeDb(AutoOrManualValue rxCellSizeDb) {
+//		this.rxCellSizeDb = rxCellSizeDb;
+//	}
+//
+//	public AutoOrManualValue getProbeResponseThresholdDb() {
+//		return probeResponseThresholdDb;
+//	}
+//
+//	public void setProbeResponseThresholdDb(AutoOrManualValue probeResponseThresholdDb) {
+//		this.probeResponseThresholdDb = probeResponseThresholdDb;
+//	}
+//
+//	public AutoOrManualValue getClientDisconnectThresholdDb() {
+//		return clientDisconnectThresholdDb;
+//	}
+//
+//	public void setClientDisconnectThresholdDb(AutoOrManualValue clientDisconnectThresholdDb) {
+//		this.clientDisconnectThresholdDb = clientDisconnectThresholdDb;
+//	}
+//
+//	public AutoOrManualValue getEirpTxPower() {
+//		return eirpTxPower;
+//	}
+//
+//	public void setEirpTxPower(AutoOrManualValue eirpTxPower) {
+//		this.eirpTxPower = eirpTxPower;
+//	}
+//
+//	public Boolean getBestApEnabled() {
+//		return bestApEnabled;
+//	}
+//
+//	public void setBestApEnabled(Boolean bestApEnabled) {
+//		this.bestApEnabled = bestApEnabled;
+//	}
+//
+//	public NeighbouringAPListConfiguration getNeighbouringListApConfig() {
+//		return neighbouringListApConfig;
+//	}
+//
+//	public void setNeighbouringListApConfig(NeighbouringAPListConfiguration neighbouringListApConfig) {
+//		this.neighbouringListApConfig = neighbouringListApConfig;
+//	}
+//
+//	public int getMinAutoCellSize(RadioType radioType) {
+//		if (minAutoCellSize == null) {
+//			return radioType == RadioType.is2dot4GHz ? MIN_BG_RADIO_CELL_SIZE : MIN_AC_RADIO_CELL_SIZE;
+//		}
+//
+//		return minAutoCellSize;
+//	}
+//
+//	public void setMinAutoCellSize(Integer minAutoCellSize) {
+//		this.minAutoCellSize = minAutoCellSize;
+//	}
+//
+//	public Boolean getPerimeterDetectionEnabled() {
+//		return perimeterDetectionEnabled;
+//	}
+//
+//	public void setPerimeterDetectionEnabled(Boolean perimeterDetectionEnabled) {
+//		this.perimeterDetectionEnabled = perimeterDetectionEnabled;
+//	}
+//
+//	public ChannelHopSettings getChannelHopSettings() {
+//		return channelHopSettings;
+//	}
+//
+//	public void setChannelHopSettings(ChannelHopSettings channelHopSettings) {
+//		this.channelHopSettings = channelHopSettings;
+//	}
+//
+//	public RadioBestApSettings getBestApSettings() {
+//		return bestApSettings;
+//	}
+//
+//	public void setBestApSettings(RadioBestApSettings bestApSettings) {
+//		this.bestApSettings = bestApSettings;
+//	}
+
+	@Override
+    public RfElementConfiguration clone() {
+        return (RfElementConfiguration) super.clone();
+    }
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((activeScanSettings == null) ? 0 : activeScanSettings.hashCode());
+		result = prime * result + (autoChannelSelection ? 1231 : 1237);
+		result = prime * result + ((beaconInterval == null) ? 0 : beaconInterval.hashCode());
+//		result = prime * result + ((bestApEnabled == null) ? 0 : bestApEnabled.hashCode());
+//		result = prime * result + ((bestApSettings == null) ? 0 : bestApSettings.hashCode());
+		result = prime * result + ((channelBandwidth == null) ? 0 : channelBandwidth.hashCode());
+//		result = prime * result + ((channelHopSettings == null) ? 0 : channelHopSettings.hashCode());
+//		result = prime * result + ((clientDisconnectThresholdDb == null) ? 0 : clientDisconnectThresholdDb.hashCode());
+//		result = prime * result + ((eirpTxPower == null) ? 0 : eirpTxPower.hashCode());
+		result = prime * result + ((forceScanDuringVoice == null) ? 0 : forceScanDuringVoice.hashCode());
+//		result = prime * result + ((managementRate == null) ? 0 : managementRate.hashCode());
+		result = prime * result + ((maxNumClients == null) ? 0 : maxNumClients.hashCode());
+		result = prime * result + ((mimoMode == null) ? 0 : mimoMode.hashCode());
+//		result = prime * result + ((minAutoCellSize == null) ? 0 : minAutoCellSize.hashCode());
+		result = prime * result + ((multicastRate == null) ? 0 : multicastRate.hashCode());
+//		result = prime * result + ((neighbouringListApConfig == null) ? 0 : neighbouringListApConfig.hashCode());
+//		result = prime * result + ((perimeterDetectionEnabled == null) ? 0 : perimeterDetectionEnabled.hashCode());
+//		result = prime * result + ((probeResponseThresholdDb == null) ? 0 : probeResponseThresholdDb.hashCode());
+		result = prime * result + ((rf == null) ? 0 : rf.hashCode());
+		result = prime * result + ((rtsCtsThreshold == null) ? 0 : rtsCtsThreshold.hashCode());
+//		result = prime * result + ((rxCellSizeDb == null) ? 0 : rxCellSizeDb.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RfElementConfiguration other = (RfElementConfiguration) obj;
+		if (activeScanSettings == null) {
+			if (other.activeScanSettings != null)
+				return false;
+		} else if (!activeScanSettings.equals(other.activeScanSettings))
+			return false;
+		if (autoChannelSelection != other.autoChannelSelection)
+			return false;
+		if (beaconInterval == null) {
+			if (other.beaconInterval != null)
+				return false;
+		} else if (!beaconInterval.equals(other.beaconInterval))
+			return false;
+//		if (bestApEnabled == null) {
+//			if (other.bestApEnabled != null)
+//				return false;
+//		} else if (!bestApEnabled.equals(other.bestApEnabled))
+//			return false;
+//		if (bestApSettings == null) {
+//			if (other.bestApSettings != null)
+//				return false;
+//		} else if (!bestApSettings.equals(other.bestApSettings))
+//			return false;
+		if (channelBandwidth != other.channelBandwidth)
+			return false;
+//		if (channelHopSettings == null) {
+//			if (other.channelHopSettings != null)
+//				return false;
+//		} else if (!channelHopSettings.equals(other.channelHopSettings))
+//			return false;
+//		if (clientDisconnectThresholdDb == null) {
+//			if (other.clientDisconnectThresholdDb != null)
+//				return false;
+//		} else if (!clientDisconnectThresholdDb.equals(other.clientDisconnectThresholdDb))
+//			return false;
+//		if (eirpTxPower == null) {
+//			if (other.eirpTxPower != null)
+//				return false;
+//		} else if (!eirpTxPower.equals(other.eirpTxPower))
+//			return false;
+		if (forceScanDuringVoice != other.forceScanDuringVoice)
+			return false;
+//		if (managementRate != other.managementRate)
+//			return false;
+		if (maxNumClients == null) {
+			if (other.maxNumClients != null)
+				return false;
+		} else if (!maxNumClients.equals(other.maxNumClients))
+			return false;
+		if (mimoMode != other.mimoMode)
+			return false;
+//		if (minAutoCellSize == null) {
+//			if (other.minAutoCellSize != null)
+//				return false;
+//		} else if (!minAutoCellSize.equals(other.minAutoCellSize))
+//			return false;
+		if (multicastRate != other.multicastRate)
+			return false;
+//		if (neighbouringListApConfig == null) {
+//			if (other.neighbouringListApConfig != null)
+//				return false;
+//		} else if (!neighbouringListApConfig.equals(other.neighbouringListApConfig))
+//			return false;
+//		if (perimeterDetectionEnabled == null) {
+//			if (other.perimeterDetectionEnabled != null)
+//				return false;
+//		} else if (!perimeterDetectionEnabled.equals(other.perimeterDetectionEnabled))
+//			return false;
+//		if (probeResponseThresholdDb == null) {
+//			if (other.probeResponseThresholdDb != null)
+//				return false;
+//		} else if (!probeResponseThresholdDb.equals(other.probeResponseThresholdDb))
+//			return false;
+		if (rf == null) {
+			if (other.rf != null)
+				return false;
+		} else if (!rf.equals(other.rf))
+			return false;
+		if (rtsCtsThreshold == null) {
+			if (other.rtsCtsThreshold != null)
+				return false;
+		} else if (!rtsCtsThreshold.equals(other.rtsCtsThreshold))
+			return false;
+//		if (rxCellSizeDb == null) {
+//			if (other.rxCellSizeDb != null)
+//				return false;
+//		} else if (!rxCellSizeDb.equals(other.rxCellSizeDb))
+//			return false;
+		return true;
+	}
+	
+	@Override
+	public boolean hasUnsupportedValue() {
+		if (super.hasUnsupportedValue()) {
+			return true;
+		}
+		if (StateSetting.isUnsupported(forceScanDuringVoice) || ChannelBandwidth.isUnsupported(channelBandwidth)
+				|| MimoMode.isUnsupported(mimoMode) || MulticastRate.isUnsupported(multicastRate) 
+//				|| ManagementRate.isUnsupported(managementRate)
+				|| ActiveScanSettings.hasUnsupportedValue(activeScanSettings) 
+//				|| AutoOrManualValue.hasUnsupportedValue(rxCellSizeDb) 
+//				|| AutoOrManualValue.hasUnsupportedValue(probeResponseThresholdDb) || AutoOrManualValue.hasUnsupportedValue(clientDisconnectThresholdDb) 
+//				|| AutoOrManualValue.hasUnsupportedValue(eirpTxPower) || NeighbouringAPListConfiguration.hasUnsupportedValue(neighbouringListApConfig)
+//				|| ChannelHopSettings.hasUnsupportedValue(channelHopSettings) || RadioBestApSettings.hasUnsupportedValue(bestApSettings)
+				) {
+			return true;
+		}
+		return false;
+	}
+
+}

--- a/profile-models/src/test/java/com/telecominfraproject/wlan/profile/rf/models/RfConfigurationTests.java
+++ b/profile-models/src/test/java/com/telecominfraproject/wlan/profile/rf/models/RfConfigurationTests.java
@@ -1,0 +1,24 @@
+package com.telecominfraproject.wlan.profile.rf.models;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.telecominfraproject.wlan.core.model.equipment.AutoOrManualValue;
+import com.telecominfraproject.wlan.core.model.equipment.RadioType;
+
+public class RfConfigurationTests {
+	
+	@Test
+	public void safeguardForAutoSelection()
+	{
+		
+		for (RadioType radioType : RadioType.validValues()) {
+		RfElementConfiguration rfConfig = RfElementConfiguration.createWithDefaults(radioType);
+		assertEquals("This should never be 'enabled' by default, it really interferes with our"
+				+ "cloud-based auto channel rebalancing", false, rfConfig.getAutoChannelSelection());
+		}
+	}
+
+}

--- a/profile-models/src/test/java/com/telecominfraproject/wlan/profile/rf/models/RfConfigurationTests.java
+++ b/profile-models/src/test/java/com/telecominfraproject/wlan/profile/rf/models/RfConfigurationTests.java
@@ -10,15 +10,15 @@ import com.telecominfraproject.wlan.core.model.equipment.RadioType;
 
 public class RfConfigurationTests {
 	
-	@Test
-	public void safeguardForAutoSelection()
-	{
-		
-		for (RadioType radioType : RadioType.validValues()) {
-		RfElementConfiguration rfConfig = RfElementConfiguration.createWithDefaults(radioType);
-		assertEquals("This should never be 'enabled' by default, it really interferes with our"
-				+ "cloud-based auto channel rebalancing", false, rfConfig.getAutoChannelSelection());
-		}
-	}
+//	@Test
+//	public void safeguardForAutoSelection()
+//	{
+//		
+//		for (RadioType radioType : RadioType.validValues()) {
+//		RfElementConfiguration rfConfig = RfElementConfiguration.createWithDefaults(radioType);
+//		assertEquals("This should never be 'enabled' by default, it really interferes with our"
+//				+ "cloud-based auto channel rebalancing", false, rfConfig.getAutoChannelSelection());
+//		}
+//	}
 
 }

--- a/profile-service/src/main/resources/profile-service-openapi.yaml
+++ b/profile-service/src/main/resources/profile-service-openapi.yaml
@@ -75,6 +75,7 @@ components:
         - radius
         - captive_portal
         - mesh
+        - rf
 
     Profile:
       description: Each AccessPoint refers to at most one profile of type equipment_ap. Each ApNetworkConfiguration (equipment_ap) profile refers to 0-N SSID profiles via its childProfileIds property. Each SSID profile refers to at most 1 Captive Portal Profile and 1 Bonjour Gateway Profile and 1 RADIUS Service Profile via its childProfileIds property. Each Captive Portal Profile refers to at most 1 RADIUS Service Profile via its childProfileIds property.
@@ -124,6 +125,7 @@ components:
           - MeshGroup
           - RadiusProfile
           - SsidConfiguration
+          - RfConfiguration
       required: 
         - model_type
 
@@ -135,6 +137,7 @@ components:
         - $ref: '#/components/schemas/MeshGroup'
         - $ref: '#/components/schemas/RadiusProfile'
         - $ref: '#/components/schemas/SsidConfiguration'
+        - $ref: '#/components/schemas/RfConfiguration'
       discriminator:
         propertyName: model_type
         
@@ -608,6 +611,99 @@ components:
           format: int32
         
     
+    MimoMode:
+      type: string
+      enum:
+        - none
+        - oneByOne
+        - twoByTwo
+        - threeByThree
+        - fourByFour
+        
+    MulticastRate:
+      type: string
+      enum:
+        - auto
+        - rate6mbps
+        - rate9mbps
+        - rate12mbps
+        - rate18mbps
+        - rate24mbps
+        - rate36mbps
+        - rate48mbps
+        - rate54mbps
+        
+    ActiveScanSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        scanFrequencySeconds:
+          type: integer
+          format: int32
+        scanDurationMillis:
+          type: integer
+          format: int32
+          
+    ChannelBandwidth:
+      description: On 2.4GHz radio only auto or is20MHz values can be used. On 5GHz radio all values can be used. 
+      type: string
+      enum:
+        - auto
+        - is20MHz
+        - is40MHz
+        - is80MHz
+        - is160MHz
+        
+    RfConfiguration:
+      description: Properties for the RF ConfigurationProfile
+      allOf:
+      - $ref: '#/components/schemas/ProfileDetails'
+      - type: object
+        properties:
+          rfConfigMap:
+            $ref: '#/components/schemas/RfConfigMap'
+    
+    RfConfigMap:
+      properties:
+        is2dot4GHz:
+          $ref: '#/components/schemas/RfElementConfiguration'
+        is5GHz:
+          $ref: '#/components/schemas/RfElementConfiguration'
+        is5GHzU:
+          $ref: '#/components/schemas/RfElementConfiguration'
+        is5GHzL:
+          $ref: '#/components/schemas/RfElementConfiguration'
+    
+    RfElementConfiguration:
+      properties:
+        model_type:
+          type: string
+          enum:
+          - RfElementConfiguration
+        rf:
+          type: string
+        beaconInterval:
+          type: integer
+          format: int32
+        forceScanDuringVoice:
+          $ref: '#/components/schemas/StateSetting'
+        rtsCtsThreshold:
+          type: integer
+          format: int32
+        channelBandwidth:
+          $ref: '#/components/schemas/ChannelBandwidth'
+        mimoMode:
+          $ref: '#/components/schemas/MimoMode'
+        maxNumClients:
+          type: integer
+          format: int32
+        multicastRate:
+          $ref: '#/components/schemas/MulticastRate'
+        autoChannelSelection:
+          type: boolean
+        activeScanSettings:
+          $ref: '#/components/schemas/ActiveScanSettings'
 
     SsidConfiguration:
       description: Properties for the SSID Configuration profile.
@@ -1106,12 +1202,4 @@ paths:
         500: 
           $ref: '#/components/responses/GenericApiError'
           
-
-
-
-
-
-
-
-
-
+          


### PR DESCRIPTION
The code added in this PR is only adding the RF profile code structure.
- RF profile type and base RfConfiguration files added
- In RfConfiguration, commented out the future parameters that are RRM related that have been marked to be moved into RF Profile. These will be in the next iteration after we determine the impact and required changes to move these parameters over. 
- Profile and Portal schemas updated to reflect RfConfiguration additions

Note that these parameters have not yet been removed from the current location of ApElementConfiguration. I am still working on resolving the code base that is impacted by the removal of these parameters from ApElementConfiguration and into the RfConfiguration.

This PR will enable the other PR going into wlan-cloud-opensync-controller of the same story. 
https://github.com/Telecominfraproject/wlan-cloud-opensync-controller/pull/5