### PR TITLE
fix OpenAPI spec for portal service

### DIFF
--- a/portal-services/src/main/resources/portal-services-openapi.yaml
+++ b/portal-services/src/main/resources/portal-services-openapi.yaml
@@ -676,6 +676,8 @@ components:
 
     DaysOfWeekTimeRangeSchedule:
       type: object
+      required:
+        - model_type
       properties:
         timezone:
           type: string
@@ -687,6 +689,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DayOfWeek'
+        model_type:
+          type: string
     
     LocalTimeValue:
       type: object
@@ -709,6 +713,8 @@ components:
 
     DailyTimeRangeSchedule:
       type: object
+      required:
+        - model_type
       properties:
         timezone:
           type: string
@@ -716,6 +722,9 @@ components:
           $ref: '#/components/schemas/LocalTimeValue'
         timeEnd:
           $ref: '#/components/schemas/LocalTimeValue'
+        model_type:
+          type: string
+
       example:
         model_type: DailyTimeRangeSchedule
         timezone: "US/Eastern"
@@ -728,10 +737,15 @@ components:
 
     EmptySchedule:
       description: This schedule setting will never return any TimeWindows.
+      required:
+        - model_type
       type: object
       properties:
         timezone:
           type: string
+        model_type:
+          type: string
+
       example:
         model_type: EmptySchedule
         timezone: "US/Eastern"
@@ -909,7 +923,11 @@ components:
 
     ApElementConfiguration:
       type: object
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         elementConfigVersion:
           type: string
         equipmentType:
@@ -2961,6 +2979,8 @@ components:
         propertyName: model_type
     
     CustomerPortalDashboardStatus:
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3003,6 +3023,8 @@ components:
       
     ActiveBSSIDs:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3037,6 +3059,8 @@ components:
 
     ClientConnectionDetails:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3082,6 +3106,8 @@ components:
 
     EquipmentAdminStatusData:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3106,6 +3132,8 @@ components:
 
     EquipmentLANStatusData:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3144,6 +3172,8 @@ components:
 
     EquipmentNeighbouringStatusData:
       description: TODO - either describe the properties of this object or remove it.
+      required:
+        - model_type
       type: object
       properties:
         model_type:
@@ -3157,6 +3187,8 @@ components:
 
     EquipmentPeerStatusData:
       description: TODO - either describe the properties of this object or remove it.
+      required:
+        - model_type
       type: object
       properties:
         model_type:
@@ -3171,6 +3203,8 @@ components:
 
     EquipmentProtocolStatusData:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3248,6 +3282,8 @@ components:
 
     EquipmentScanDetails:
       description: TODO - document it or remove it
+      required:
+        - model_type
       type: object
       properties:
         model_type:
@@ -3263,6 +3299,8 @@ components:
 
     EquipmentUpgradeStatusData:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3329,6 +3367,8 @@ components:
 
     NetworkAdminStatusData:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3398,6 +3438,8 @@ components:
       
     NetworkAggregateStatusData:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3809,6 +3851,8 @@ components:
 
     OperatingSystemPerformance:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -3846,6 +3890,8 @@ components:
 
     RadioUtilizationReport:
       type: object
+      required:
+        - model_type
       properties:
         model_type:
           type: string
@@ -4640,7 +4686,11 @@ components:
         propertyName: model_type
 
     NeighbourScanReports:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         neighbourReports:
           type: array
           items:
@@ -4738,7 +4788,11 @@ components:
       - SGI# Short Guard Interval
 
     ClientMetrics:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         secondsSinceLastRecv:
           type: integer
           format: int32
@@ -6215,7 +6269,11 @@ components:
         
     
     ChannelInfoReports:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         channelInformationReportsPerRadio:
           $ref: '#/components/schemas/ListOfChannelInfoReportsPerRadioMap'
 
@@ -6257,7 +6315,11 @@ components:
         
 
     ApSsidMetrics:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         ssidStats:
           $ref: '#/components/schemas/ListOfSsidStatisticsPerRadioMap'
 
@@ -6525,7 +6587,11 @@ components:
       
     ApNodeMetrics:
       type: object
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         periodLengthSec:
           description: How many seconds the AP measured for the metric
           type: integer
@@ -8750,7 +8816,11 @@ components:
         propertyName: model_type
         
     GatewayAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8758,7 +8828,11 @@ components:
           $ref: '#/components/schemas/EquipmentGatewayRecord'
 
     GatewayChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8766,7 +8840,11 @@ components:
           $ref: '#/components/schemas/EquipmentGatewayRecord'
 
     GatewayRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8774,7 +8852,11 @@ components:
           $ref: '#/components/schemas/EquipmentGatewayRecord'
           
     RoutingAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8788,7 +8870,11 @@ components:
           $ref: '#/components/schemas/EquipmentRoutingRecord'
 
     RoutingChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8802,7 +8888,11 @@ components:
           $ref: '#/components/schemas/EquipmentRoutingRecord'
 
     RoutingRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8816,7 +8906,11 @@ components:
           $ref: '#/components/schemas/EquipmentRoutingRecord'
 
     ClientAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8827,7 +8921,11 @@ components:
           $ref: '#/components/schemas/Client'
 
     ClientChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8838,7 +8936,11 @@ components:
           $ref: '#/components/schemas/Client'
 
     ClientRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8849,7 +8951,11 @@ components:
           $ref: '#/components/schemas/Client'
 
     ClientSessionChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8863,7 +8969,11 @@ components:
           $ref: '#/components/schemas/ClientSession'
 
     ClientSessionRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8877,7 +8987,11 @@ components:
           $ref: '#/components/schemas/ClientSession'
 
     CustomerAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8888,7 +9002,11 @@ components:
           $ref: '#/components/schemas/Customer'
 
     CustomerChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8899,7 +9017,11 @@ components:
           $ref: '#/components/schemas/Customer'
 
     CustomerRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8910,7 +9032,11 @@ components:
           $ref: '#/components/schemas/Customer'
 
     LocationAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8921,7 +9047,11 @@ components:
           $ref: '#/components/schemas/Location'
 
     LocationChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8932,7 +9062,11 @@ components:
           $ref: '#/components/schemas/Location'
 
     LocationRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8943,7 +9077,11 @@ components:
           $ref: '#/components/schemas/Location'
 
     EquipmentAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8957,7 +9095,11 @@ components:
           $ref: '#/components/schemas/Equipment'
 
     EquipmentChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8971,7 +9113,11 @@ components:
           $ref: '#/components/schemas/Equipment'
 
     EquipmentRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8985,7 +9131,11 @@ components:
           $ref: '#/components/schemas/Equipment'
 
     AlarmAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -8999,7 +9149,11 @@ components:
           $ref: '#/components/schemas/Alarm'
 
     AlarmChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9013,7 +9167,11 @@ components:
           $ref: '#/components/schemas/Alarm'
 
     AlarmRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9027,7 +9185,11 @@ components:
           $ref: '#/components/schemas/Alarm'
 
     PortalUserAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9038,7 +9200,11 @@ components:
           $ref: '#/components/schemas/PortalUser'
 
     PortalUserChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9049,7 +9215,11 @@ components:
           $ref: '#/components/schemas/PortalUser'
 
     PortalUserRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9060,7 +9230,11 @@ components:
           $ref: '#/components/schemas/PortalUser'
 
     ProfileAddedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9071,7 +9245,11 @@ components:
           $ref: '#/components/schemas/Profile'
 
     ProfileChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9082,7 +9260,11 @@ components:
           $ref: '#/components/schemas/Profile'
 
     ProfileRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9093,7 +9275,11 @@ components:
           $ref: '#/components/schemas/Profile'
 
     StatusChangedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9107,7 +9293,11 @@ components:
           $ref: '#/components/schemas/Status'
 
     StatusRemovedEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64
@@ -9121,7 +9311,11 @@ components:
           $ref: '#/components/schemas/Status'
           
     BaseDhcpEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/SystemEvent'
         xId:
@@ -9152,7 +9346,11 @@ components:
           format: int64
           
     DhcpAckEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent'
         subnetMask:
@@ -9181,24 +9379,40 @@ components:
           type: string
                        
     DhcpDeclineEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent'   
 
     DhcpDiscoverEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent'
         hostName:
           type: string
              
     DhcpInformEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent'   
     
     DhcpNakEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent' 
         fromInternal:
@@ -9206,7 +9420,11 @@ components:
           default: false
     
     DhcpOfferEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent'   
         fromInternal:
@@ -9214,14 +9432,22 @@ components:
           default: false
     
     DhcpRequestEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/BaseDhcpEvent'   
         hostName:
           type: string 
               
     RealTimeEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/SystemEvent'
         eventTimestamp:
@@ -9235,7 +9461,11 @@ components:
           format: int64
           
     ClientAssocEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9265,7 +9495,11 @@ components:
           type: boolean
 
     ClientConnectSuccessEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         clientMacAddress:
@@ -9320,7 +9554,11 @@ components:
           format: int32
 
     ClientFailureEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9336,7 +9574,11 @@ components:
           type: string    
 
     ClientIdEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9360,7 +9602,11 @@ components:
         - UNSUPPORTED
 
     ClientTimeoutEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9378,7 +9624,11 @@ components:
           $ref: '#/components/schemas/ClientTimeoutReason'
 
     ClientAuthEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9410,7 +9660,11 @@ components:
         - UNSUPPORTED
         
     ClientDisconnectEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9447,7 +9701,11 @@ components:
           $ref: '#/components/schemas/DisconnectInitiator'
 
     ClientFirstDataEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sessionId:
@@ -9463,7 +9721,11 @@ components:
           format: int64
           
     ClientIpAddressEvent :
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'   
         sessionId:
@@ -9485,7 +9747,11 @@ components:
         - UNSUPPORTED
         
     RealtimeChannelHopEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         oldChannel:
@@ -9500,7 +9766,11 @@ components:
           $ref: '#/components/schemas/RadioType'   
           
     RealTimeSipCallEventWithStats:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sipCallId:
@@ -9527,23 +9797,23 @@ components:
         providerDomain:
           type: string
 
-    SIPCallReportReason:
-      type: string
-      enum:
-        - ROAMED_FROM
-        - ROAMED_TO
-        - GOT_PUBLISH
-        - UNSUPPORTED
-        
     RealTimeSipCallReportEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeSipCallEventWithStats'
         reportReason:
-          $ref: '#/components/schemas/SIPCallReportReason'
+          $ref: '#/components/schemas/SipCallReportReason'
         
     RealTimeSipCallStartEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         sipCallId:
@@ -9576,7 +9846,11 @@ components:
         - UNSUPPORTED      
 
     RealTimeSipCallStopEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         callDuration:
@@ -9586,7 +9860,11 @@ components:
           $ref: '#/components/schemas/SipCallStopReason'
 
     RealTimeStreamingStartEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         videoSessionId:
@@ -9606,7 +9884,11 @@ components:
           $ref: '#/components/schemas/StreamingVideoType'
 
     RealTimeStreamingStartSessionEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         videoSessionId:
@@ -9624,7 +9906,11 @@ components:
           $ref: '#/components/schemas/StreamingVideoType'
  
     RealTimeStreamingStopEvent:
+      required:
+        - model_type
       properties:
+        model_type:
+          type: string
         allOf:
           $ref: '#/components/schemas/RealTimeEvent'
         videoSessionId:
@@ -9728,8 +10014,12 @@ components:
           format: int64
 
     UnserializableSystemEvent:
+      required:
+        - model_type
       description: This event is used in situations when the cloud cannot parse the event that was previously stored in the DB, used to cover upgrade scenarios.
       properties:
+        model_type:
+          type: string
         eventTimestamp:
           type: integer
           format: int64

--- a/portal-services/src/main/resources/portal-services-openapi.yaml
+++ b/portal-services/src/main/resources/portal-services-openapi.yaml
@@ -9806,7 +9806,7 @@ components:
         allOf:
           $ref: '#/components/schemas/RealTimeSipCallEventWithStats'
         reportReason:
-          $ref: '#/components/schemas/SipCallReportReason'
+          $ref: '#/components/schemas/SIPCallReportReason'
         
     RealTimeSipCallStartEvent:
       required:
@@ -9973,7 +9973,7 @@ components:
         - VIDEO
         - UNSUPPORTED
     
-    SipCallReportReason:
+    SIPCallReportReason:
       type: string
       enum:
         - ROAMED_FROM


### PR DESCRIPTION
These changes fix the Python client code generation using the openapi-generator (`openapi-generator-cli  generate -i portal-services-openapi.yaml -g python -o portal_client`).

Please be aware that I have no idea about the consequences of these changes. I only focused on fixing the code generation.