### PR TITLE
WIFI-1718 Updated getAverageSignalStrenght for neighboring APs

### DIFF
--- a/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/ManagedNeighbourEquipmentInfo.java
+++ b/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/ManagedNeighbourEquipmentInfo.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.telecominfraproject.wlan.core.model.equipment.RadioType;
+import com.telecominfraproject.wlan.core.model.utils.DecibelUtils;
 
 /**
  * @author ekeddy
@@ -59,28 +60,22 @@ public class ManagedNeighbourEquipmentInfo extends NeighbourEquipmentInfo {
 	public Integer getAverageSignalStrenght(RadioType radioType)
 	{
 	   NeighbourRadioInfo info = getRadioInfo(radioType);
-	   
-	   int runningTotal = 0;
+	   Integer returnValue = null; 
 	   int numEntries = 0;
+	   int[] rssiList;
 	   
 	   if(info != null)
 	   {
+		  rssiList = new int[info.getBssIds().size()];
 	      for(NeighbourBssidInfo singleBssidInfo :  info.getBssIds())
 	      {
-	         runningTotal += singleBssidInfo.getSignal();
-	         numEntries++;
+	         rssiList[numEntries++] = singleBssidInfo.getRssi();   
 	      }
+		  if (numEntries != 0) {
+			  returnValue = (int) Math.round(DecibelUtils.getAverageDecibel(rssiList));
+		  }
 	   }
-	   
-	   if(numEntries != 0)
-	   {
-	      return runningTotal / numEntries;
-	   }
-	   else
-	   {
-	      return null;
-	   }
-	   
+	   return returnValue;
 	}
 
 	@JsonIgnore

--- a/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/ManagedNeighbourEquipmentInfo.java
+++ b/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/ManagedNeighbourEquipmentInfo.java
@@ -60,22 +60,18 @@ public class ManagedNeighbourEquipmentInfo extends NeighbourEquipmentInfo {
 	public Integer getAverageSignalStrenght(RadioType radioType)
 	{
 	   NeighbourRadioInfo info = getRadioInfo(radioType);
-	   Integer returnValue = null; 
-	   int numEntries = 0;
-	   int[] rssiList;
+	   List<Integer> rssiList = new ArrayList<>();
 	   
-	   if(info != null)
-	   {
-		  rssiList = new int[info.getBssIds().size()];
-	      for(NeighbourBssidInfo singleBssidInfo :  info.getBssIds())
-	      {
-	         rssiList[numEntries++] = singleBssidInfo.getRssi();   
+	   if(info != null && info.getBssIds() != null){
+	      for(NeighbourBssidInfo singleBssidInfo :  info.getBssIds()){
+	         rssiList.add(singleBssidInfo.getRssi());   
 	      }
-		  if (numEntries != 0) {
-			  returnValue = (int) Math.round(DecibelUtils.getAverageDecibel(rssiList));
-		  }
 	   }
-	   return returnValue;
+	   if (!rssiList.isEmpty()){
+		   return (int) Math.round(DecibelUtils.getAverageDecibel(rssiList));
+	   }else{
+		   return null;
+	   }
 	}
 
 	@JsonIgnore

--- a/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/ManagedNeighbourEquipmentInfo.java
+++ b/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/ManagedNeighbourEquipmentInfo.java
@@ -63,10 +63,9 @@ public class ManagedNeighbourEquipmentInfo extends NeighbourEquipmentInfo {
 	   List<Integer> rssiList = new ArrayList<>();
 	   
 	   if(info != null && info.getBssIds() != null){
-	      for(NeighbourBssidInfo singleBssidInfo :  info.getBssIds()){
-	         rssiList.add(singleBssidInfo.getRssi());   
-	      }
+		   info.getBssIds().forEach(bssId -> rssiList.add(bssId.getRssi()));
 	   }
+	   
 	   if (!rssiList.isEmpty()){
 		   return (int) Math.round(DecibelUtils.getAverageDecibel(rssiList));
 	   }else{

--- a/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/UnmanagedNeighbourEquipmentInfo.java
+++ b/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/UnmanagedNeighbourEquipmentInfo.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.telecominfraproject.wlan.core.model.equipment.MacAddress;
 import com.telecominfraproject.wlan.core.model.equipment.RadioType;
+import com.telecominfraproject.wlan.core.model.utils.DecibelUtils;
 
 /**
  * Contains scan information from neigbouring equipment that is not managed by
@@ -71,21 +72,24 @@ public class UnmanagedNeighbourEquipmentInfo extends NeighbourEquipmentInfo {
 
     @JsonIgnore
     public int getAverageSignalStrenght(RadioType radioType) {
-        int runningTotal = 0;
-        int numEntries = 0;
-
+        List<Integer> rssiList = new ArrayList<>();
+        
         for (NeighbourRadioInfo radioInfo : this.radios) {
             if (radioInfo.getRadioType() == radioType) {
                 for (NeighbourBssidInfo bssInfo : radioInfo.getBssIds()) {
-                    runningTotal += bssInfo.getSignal();
-                    numEntries++;
+                    rssiList.add(bssInfo.getRssi());
                 }
             }
-
         }
 
-        if (numEntries > 0) {
-            return runningTotal / numEntries;
+        if (rssiList.size() > 0) {
+        	int[] rssiArray = new int[rssiList.size()];
+        	int index = 0;
+        	for (Integer rssi : rssiList) {
+        		rssiArray[index++] = rssi;
+        	}
+ 
+            return (int) Math.round(DecibelUtils.getAverageDecibel(rssiArray));
         } else {
             return 0;
         }

--- a/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/UnmanagedNeighbourEquipmentInfo.java
+++ b/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/UnmanagedNeighbourEquipmentInfo.java
@@ -79,10 +79,7 @@ public class UnmanagedNeighbourEquipmentInfo extends NeighbourEquipmentInfo {
 	        {
 	            if (radioInfo != null && radioInfo.getBssIds() != null && radioInfo.getRadioType() == radioType) 
 	            {
-	                for (NeighbourBssidInfo bssInfo : radioInfo.getBssIds()) 
-	                {
-	                    rssiList.add(bssInfo.getRssi());
-	                }
+                   radioInfo.getBssIds().forEach(bssInfo -> rssiList.add(bssInfo.getRssi()));
 	            }
 	        }
         }

--- a/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/UnmanagedNeighbourEquipmentInfo.java
+++ b/status-models/src/main/java/com/telecominfraproject/wlan/status/equipment/report/models/UnmanagedNeighbourEquipmentInfo.java
@@ -71,27 +71,26 @@ public class UnmanagedNeighbourEquipmentInfo extends NeighbourEquipmentInfo {
     }
 
     @JsonIgnore
-    public int getAverageSignalStrenght(RadioType radioType) {
+    public Integer getAverageSignalStrenght(RadioType radioType) {
         List<Integer> rssiList = new ArrayList<>();
-        
-        for (NeighbourRadioInfo radioInfo : this.radios) {
-            if (radioInfo.getRadioType() == radioType) {
-                for (NeighbourBssidInfo bssInfo : radioInfo.getBssIds()) {
-                    rssiList.add(bssInfo.getRssi());
-                }
-            }
+        if (this.radios != null) 
+        {
+	        for (NeighbourRadioInfo radioInfo : this.radios) 
+	        {
+	            if (radioInfo != null && radioInfo.getBssIds() != null && radioInfo.getRadioType() == radioType) 
+	            {
+	                for (NeighbourBssidInfo bssInfo : radioInfo.getBssIds()) 
+	                {
+	                    rssiList.add(bssInfo.getRssi());
+	                }
+	            }
+	        }
         }
 
-        if (rssiList.size() > 0) {
-        	int[] rssiArray = new int[rssiList.size()];
-        	int index = 0;
-        	for (Integer rssi : rssiList) {
-        		rssiArray[index++] = rssi;
-        	}
- 
-            return (int) Math.round(DecibelUtils.getAverageDecibel(rssiArray));
+        if (!rssiList.isEmpty()) { 
+            return (int) Math.round(DecibelUtils.getAverageDecibel(rssiList));
         } else {
-            return 0;
+            return null;
         }
     }
 


### PR DESCRIPTION
###  Summary of PR:
- Updated the getAverageSignalStrenght to use the neighbouring APs RSSI values instead of signal strength. 

- Updated the calculation of the average since RSSI is in decibels which is a logarithmic scale.