### PR TITLE
WIFI 1739 client session forcustomer max items

### DIFF
--- a/client-datastore-cassandra/src/main/java/com/telecominfraproject/wlan/client/datastore/cassandra/ClientSessionDAO.java
+++ b/client-datastore-cassandra/src/main/java/com/telecominfraproject/wlan/client/datastore/cassandra/ClientSessionDAO.java
@@ -503,8 +503,8 @@ public class ClientSessionDAO {
 				// get a single client session per customerId, returned equipmentId, and returned macAddress from filter tables
 				ClientSession retSession = getSessionOrNull(customerId, eqId, macAddr);
 				
-				if (retSession != null 
-				        && (locationIds == null || locationIds.isEmpty() || locationIds.contains(retSession.getLocationId()))
+                if (retSession != null 
+                        && (locationIds == null || locationIds.isEmpty() || locationIds.contains(retSession.getLocationId()))
                         && (equipmentIds == null || equipmentIds.isEmpty() || equipmentIds.contains(retSession.getEquipmentId()))
                         && (macSubstring == null || macSubstring.isEmpty() || retSession.getMacAddress().getAddressAsString().toLowerCase().contains(macSubstring.toLowerCase()))
                         ) 

--- a/client-datastore-cassandra/src/main/java/com/telecominfraproject/wlan/client/datastore/cassandra/ClientSessionDAO.java
+++ b/client-datastore-cassandra/src/main/java/com/telecominfraproject/wlan/client/datastore/cassandra/ClientSessionDAO.java
@@ -410,7 +410,7 @@ public class ClientSessionDAO {
             queryArgs.addAll(equipmentIds);
 
             query += "and equipmentId in " + CassandraUtils.getBindPlaceholders(equipmentIds);
-            query_head = "select macAddress from client_session_by_equipment where customerId = ? ";
+            query_head = "select macAddress, equipmentId from client_session_by_equipment where customerId = ? ";
             
             filterOptions = FilterOptions.customer_and_equipment;
         }
@@ -425,7 +425,7 @@ public class ClientSessionDAO {
             }
 
             query = " locationId in " + CassandraUtils.getBindPlaceholders(locationIds) + query;
-            query_head = "select macAddress from client_session_by_location where ";
+            query_head = "select macAddress, equipmentId from client_session_by_location where ";
             
             filterOptions = FilterOptions.customer_and_location;
         }
@@ -435,7 +435,7 @@ public class ClientSessionDAO {
         	queryArgs.clear();
         	queryArgs.add(customerId);
         	queryArgs.add("%" + macSubstring.toLowerCase() + "%");
-        	query_head = "select macAddress from client_session_by_mac where customerId = ? ";
+        	query_head = "select macAddress, equipmentId from client_session_by_mac where customerId = ? ";
         	
         	if (locationIds != null && !locationIds.isEmpty()) {
         		queryArgs.addAll(locationIds);
@@ -443,7 +443,7 @@ public class ClientSessionDAO {
         	}
         	if (equipmentIds != null && !equipmentIds.isEmpty()) {
         		queryArgs.addAll(equipmentIds);
-            	query_head = "select macAddress from client_session_by_mac_and_equipment where customerId = ? ";
+            	query_head = "select macAddress, equipmentId from client_session_by_mac_and_equipment where customerId = ? ";
         	}
         	
         	query = " and macAddressString like ? " + query + " allow filtering";
@@ -494,27 +494,24 @@ public class ClientSessionDAO {
 		case customer_and_equipment:
 		case customer_and_location:
 		case customer_and_macAddress:
-			//the query was against client_session_by_equipment or client_session_by_location table
-			//find all the macAddresses for the page, then retrieve records for them from client_session table
-			Set<MacAddress> macAddrSet = new HashSet<>();
+			//the query was against client_session_by_equipment, client_session_by_location, or client_session_by_mac(_and_equipment) table
+			//find all the macAddresses and equipmentId for the page, then retrieve records for them from client_session table
 			while (rs.getAvailableWithoutFetching() > 0) {
-				macAddrSet.add(new MacAddress(rs.one().getLong("macAddress")));
-			}
-
-			//get all the sessions for the involved mac addresses
-			List<ClientSession> pageSessions = getSessions(customerId, macAddrSet);
-
-			//apply local filtering because retrieved sessions may be from different equipments and locations
-			pageSessions.forEach(cs -> {
-			    //apply locationId and equipmentId filtering in here
-                if ((locationIds == null || locationIds.isEmpty() || locationIds.contains(cs.getLocationId()))
-                        && (equipmentIds == null || equipmentIds.isEmpty() || equipmentIds.contains(cs.getEquipmentId()))
-                        && (macSubstring == null || macSubstring.isEmpty() || cs.getMacAddress().getAddressAsString().toLowerCase().contains(macSubstring.toLowerCase()))
-                		) 
+			    Row row = rs.one();
+				MacAddress macAddr = new MacAddress(row.getLong("macAddress"));
+				long eqId = row.getLong("equipmentId");
+				// get a single client session per customerId, returned equipmentId, and returned macAddress from filter tables
+				ClientSession retSession = getSessionOrNull(customerId, eqId, macAddr);
+				
+				if (retSession != null 
+				        && (locationIds == null || locationIds.isEmpty() || locationIds.contains(retSession.getLocationId()))
+                        && (equipmentIds == null || equipmentIds.isEmpty() || equipmentIds.contains(retSession.getEquipmentId()))
+                        && (macSubstring == null || macSubstring.isEmpty() || retSession.getMacAddress().getAddressAsString().toLowerCase().contains(macSubstring.toLowerCase()))
+                        ) 
                 {
-	                    pageItems.add(cs);
-	            }
-			});
+                        pageItems.add(retSession);
+                }
+			}
 
 			break;
 		default:

--- a/client-datastore-common-test/src/main/java/com/telecominfraproject/wlan/client/datastore/BaseClientDatastoreTest.java
+++ b/client-datastore-common-test/src/main/java/com/telecominfraproject/wlan/client/datastore/BaseClientDatastoreTest.java
@@ -973,6 +973,63 @@ public abstract class BaseClientDatastoreTest {
         return new ArrayList<>(Arrays.asList(new String[]{"qr_49", "qr_48", "qr_47", "qr_46", "qr_45", "qr_44", "qr_43", "qr_42", "qr_41", "qr_40" }));
     }
     
+    @Test
+    public void testClientSessionPaginationMaxItems()
+    {
+       //create 100 Client sessions
+       ClientSession mdl;
+       int customerId = (int) testSequence.incrementAndGet();
+       long locationId = testSequence.incrementAndGet();
+       
+       int apNameIdx = 0;
+       
+       List<ClientSession> sessionsToCreate = new ArrayList<>();
+       
+       for(int i = 0; i< 10; i++){
+           mdl = new ClientSession();
+           mdl.setCustomerId(customerId);
+           mdl.setLocationId(locationId);
+           mdl.setEquipmentId(testSequence.incrementAndGet());
+           mdl.setMacAddress(new MacAddress("A1:FF:FF:FF:FF:FF"));
+           
+           ClientSessionDetails details = new ClientSessionDetails();
+           details.setApFingerprint("qr_"+apNameIdx);
+           mdl.setDetails(details );
+
+           apNameIdx++;
+           
+           sessionsToCreate.add(mdl);
+       }
+       
+       List<ClientSession> createdList = testInterface.updateSessions(sessionsToCreate);
+       List<ClientSessionDetails> createdDetailsList = new ArrayList<>();
+       List<ClientSessionDetails> detailsToCreateList = new ArrayList<>();
+       
+       sessionsToCreate.forEach(s -> detailsToCreateList.add(s.getDetails()));
+       createdList.forEach(s -> createdDetailsList.add(s.getDetails()));       
+       assertEquals(detailsToCreateList, createdDetailsList);
+       
+       PaginationContext<ClientSession> context = new PaginationContext<>(5);
+       PaginationResponse<ClientSession> page1 = testInterface.getSessionsForCustomer(customerId, null, new HashSet<Long>(Arrays.asList(locationId)), null, Collections.emptyList(), context);
+
+       assertEquals(5, page1.getItems().size());
+       
+       page1 = testInterface.getSessionsForCustomer(customerId, null, null, "A1", Collections.emptyList(), context);
+
+       assertEquals(5, page1.getItems().size());
+       
+       context = new PaginationContext<>(10);
+       page1 = testInterface.getSessionsForCustomer(customerId, null, new HashSet<Long>(Arrays.asList(locationId)), null, Collections.emptyList(), context);
+
+       assertEquals(10, page1.getItems().size());
+       
+       context = new PaginationContext<>(20);
+       page1 = testInterface.getSessionsForCustomer(customerId, null, new HashSet<Long>(Arrays.asList(locationId)), null, Collections.emptyList(), context);
+
+       assertEquals(10, page1.getItems().size());
+
+       createdList.forEach(c -> testInterface.deleteSession(c.getCustomerId(), c.getEquipmentId(), c.getMacAddress()));
+    }
     
     protected ClientSession createClientSessionObject() {
     	ClientSession result = new ClientSession();


### PR DESCRIPTION
…session per returned row

- When filtering for locationId, equipmentId, or macSubstring, it will return macAddress and equipmentId to use to get a single session with customerId, returned equipmentId and macAddress per row. 
- This should return exactly the same entries as number of rows queried for from Cassandra. 