### PR TITLE
[Wifi 3041] A disconnected Alarm is raised when a disconnected AP is moved out of a Customer Inventory.

### DIFF
--- a/alarm-service-remote/pom.xml
+++ b/alarm-service-remote/pom.xml
@@ -64,20 +64,5 @@
         <version>1.2.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
-      
-      <dependency>
-        <artifactId>status-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-    
-      <dependency>
-        <artifactId>status-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-
     </dependencies>
 </project>

--- a/alarm-service/pom.xml
+++ b/alarm-service/pom.xml
@@ -1,83 +1,70 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.telecominfraproject.wlan</groupId>
-    <artifactId>tip-wlan-cloud-root-pom</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
-    <relativePath>../../wlan-cloud-root</relativePath>
-  </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.telecominfraproject.wlan</groupId>
+		<artifactId>tip-wlan-cloud-root-pom</artifactId>
+		<version>1.2.0-SNAPSHOT</version>
+		<relativePath>../../wlan-cloud-root</relativePath>
+	</parent>
 
-  <artifactId>alarm-service</artifactId>
-  <name>alarm-service</name>
-  <description>Server side implementation of the service.</description>
-  
-    <dependencies>
-      <dependency>
-        <artifactId>base-container</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>cloud-event-dispatcher-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-    <dependency>
-        <artifactId>alarm-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-        <artifactId>alarm-datastore-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-        <artifactId>equipment-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-        <artifactId>alarm-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <artifactId>equipment-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <artifactId>equipment-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-    </dependency>
+	<artifactId>alarm-service</artifactId>
+	<name>alarm-service</name>
+	<description>Server side implementation of the service.</description>
 
-      <dependency>
-        <artifactId>status-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-    
-      <dependency>
-        <artifactId>status-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <dependency>
-        <artifactId>cloud-event-dispatcher-empty</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
+	<dependencies>
+		<dependency>
+			<artifactId>base-container</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-    </dependencies>
+		<dependency>
+			<artifactId>cloud-event-dispatcher-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>alarm-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<artifactId>alarm-datastore-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<artifactId>equipment-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<artifactId>alarm-datastore-inmemory</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<artifactId>equipment-service-local</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<artifactId>equipment-datastore-inmemory</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<artifactId>cloud-event-dispatcher-empty</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/alarm-service/src/test/java/com/telecominfraproject/wlan/alarm/controller/AlarmControllerTest.java
+++ b/alarm-service/src/test/java/com/telecominfraproject/wlan/alarm/controller/AlarmControllerTest.java
@@ -22,9 +22,6 @@ import com.telecominfraproject.wlan.equipment.EquipmentServiceLocal;
 import com.telecominfraproject.wlan.equipment.controller.EquipmentController;
 import com.telecominfraproject.wlan.equipment.datastore.inmemory.EquipmentDatastoreInMemory;
 import com.telecominfraproject.wlan.equipment.models.Equipment;
-import com.telecominfraproject.wlan.status.StatusServiceLocal;
-import com.telecominfraproject.wlan.status.controller.StatusController;
-import com.telecominfraproject.wlan.status.datastore.inmemory.StatusDatastoreInMemory;
 import com.telecominfraproject.wlan.alarm.datastore.inmemory.AlarmDatastoreInMemory;
 import com.telecominfraproject.wlan.alarm.models.Alarm;
 import com.telecominfraproject.wlan.alarm.models.AlarmCode;
@@ -48,10 +45,7 @@ import com.telecominfraproject.wlan.alarm.models.AlarmDetails;
         AlarmControllerTest.Config.class, 
         EquipmentServiceLocal.class,
         EquipmentController.class,
-        EquipmentDatastoreInMemory.class,
-        StatusServiceLocal.class,
-        StatusController.class,
-        StatusDatastoreInMemory.class
+        EquipmentDatastoreInMemory.class
         })
 public class AlarmControllerTest {
     

--- a/cloud-event-dispatcher-remote/pom.xml
+++ b/cloud-event-dispatcher-remote/pom.xml
@@ -61,21 +61,6 @@
       </dependency>
       
       <dependency>
-        <artifactId>status-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-    
-      <dependency>
-        <artifactId>status-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-
-
-      <dependency>
         <artifactId>base-stream-interface</artifactId>
         <groupId>com.telecominfraproject.wlan</groupId>
         <version>1.2.0-SNAPSHOT</version>

--- a/equipment-models/src/main/java/com/telecominfraproject/wlan/equipment/models/events/EquipmentChangeType.java
+++ b/equipment-models/src/main/java/com/telecominfraproject/wlan/equipment/models/events/EquipmentChangeType.java
@@ -10,7 +10,7 @@ import com.telecominfraproject.wlan.core.model.json.JsonDeserializationUtils;
 
 public enum EquipmentChangeType {
 
-    All(0), ChannelsOnly(1), CellSizeAttributesOnly(2), ApImpacting(3), blinkLEDs(4), UNSUPPORTED(-1);
+    All(0), ChannelsOnly(1), CellSizeAttributesOnly(2), ApImpacting(3), blinkLEDs(4), CustomerOnly(5), UNSUPPORTED(-1);
 
     private final int id;
     private static final Map<Integer, EquipmentChangeType> ELEMENTS = new HashMap<>();

--- a/equipment-models/src/main/java/com/telecominfraproject/wlan/equipment/models/events/EquipmentCustomerChangedEvent.java
+++ b/equipment-models/src/main/java/com/telecominfraproject/wlan/equipment/models/events/EquipmentCustomerChangedEvent.java
@@ -1,0 +1,41 @@
+package com.telecominfraproject.wlan.equipment.models.events;
+
+import com.telecominfraproject.wlan.equipment.models.Equipment;
+
+public class EquipmentCustomerChangedEvent extends EquipmentChangedEvent {
+
+    private static final long serialVersionUID = 4650302079238674307L;
+    private Equipment existingEquipment; // old equipment
+    private Equipment equipment; // new configured equipment
+
+    public EquipmentCustomerChangedEvent(Equipment existingEquipment, Equipment equipment) {
+        super(equipment);
+        setEquipmentChangeType(EquipmentChangeType.CustomerOnly);
+        this.setExistingEquipment(existingEquipment);
+        this.setEquipment(equipment);
+    }
+
+    /**
+     * Constructor used by JSON
+     */
+    @SuppressWarnings("unused")
+    private EquipmentCustomerChangedEvent() {
+        super();
+    }
+
+    public Equipment getExistingEquipment() {
+        return existingEquipment;
+    }
+
+    public void setExistingEquipment(Equipment existingEquipment) {
+        this.existingEquipment = existingEquipment;
+    }
+
+    public Equipment getEquipment() {
+        return equipment;
+    }
+
+    public void setEquipment(Equipment equipment) {
+        this.equipment = equipment;
+    }
+}

--- a/equipment-service-remote/pom.xml
+++ b/equipment-service-remote/pom.xml
@@ -1,84 +1,58 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.telecominfraproject.wlan</groupId>
-    <artifactId>tip-wlan-cloud-root-pom</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
-    <relativePath>../../wlan-cloud-root</relativePath>
-  </parent>
-
-  <artifactId>equipment-service-remote</artifactId>
-  <name>equipment-service-remote</name>
-   <description>Remote client for accessing the service, uses REST API calls.</description>
-  
-    <dependencies>
-      <dependency>
-        <artifactId>equipment-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-		<artifactId>status-service-interface</artifactId>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
 		<groupId>com.telecominfraproject.wlan</groupId>
-		<version>${tip-wlan-cloud.release.version}</version>
-	  </dependency>
-      
-      <dependency>
-        <artifactId>base-client</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<artifactId>tip-wlan-cloud-root-pom</artifactId>
+		<version>1.2.0-SNAPSHOT</version>
+		<relativePath>../../wlan-cloud-root</relativePath>
+	</parent>
 
-    <!-- Dependencies for the unit tests -->
-      <dependency>
-        <artifactId>base-remote-tests</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <dependency>
-        <artifactId>equipment-service</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
+	<artifactId>equipment-service-remote</artifactId>
+	<name>equipment-service-remote</name>
+	<description>Remote client for accessing the service, uses REST API calls.</description>
 
-      <dependency>
-        <artifactId>equipment-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
+	<dependencies>
+		<dependency>
+			<artifactId>equipment-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>cloud-event-dispatcher-empty</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-      
-     <dependency>
-        <artifactId>status-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
+		<dependency>
+			<artifactId>base-client</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>status-service</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-    
-     <dependency>
-        <artifactId>status-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
+		<!-- Dependencies for the unit tests -->
+		<dependency>
+			<artifactId>base-remote-tests</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
 
-    </dependencies>
+		<dependency>
+			<artifactId>equipment-service</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<artifactId>equipment-datastore-inmemory</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<artifactId>cloud-event-dispatcher-empty</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/equipment-service/pom.xml
+++ b/equipment-service/pom.xml
@@ -50,31 +50,10 @@
 		</dependency>
 
 		<dependency>
-			<artifactId>status-service-interface</artifactId>
-			<groupId>com.telecominfraproject.wlan</groupId>
-			<version>1.2.0-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
-			<artifactId>status-service-local</artifactId>
-			<groupId>com.telecominfraproject.wlan</groupId>
-			<version>1.2.0-SNAPSHOT</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<artifactId>status-datastore-inmemory</artifactId>
-			<groupId>com.telecominfraproject.wlan</groupId>
-			<version>1.2.0-SNAPSHOT</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<artifactId>cloud-event-dispatcher-empty</artifactId>
 			<groupId>com.telecominfraproject.wlan</groupId>
 			<version>1.2.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 </project>

--- a/equipment-service/pom.xml
+++ b/equipment-service/pom.xml
@@ -1,72 +1,80 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.telecominfraproject.wlan</groupId>
-    <artifactId>tip-wlan-cloud-root-pom</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
-    <relativePath>../../wlan-cloud-root</relativePath>
-  </parent>
-
-  <artifactId>equipment-service</artifactId>
-  <name>equipment-service</name>
-  <description>Server side implementation of the service.</description>
-  
-    <dependencies>
-      <dependency>
-        <artifactId>base-container</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>cloud-event-dispatcher-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>equipment-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <artifactId>equipment-datastore-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <artifactId>equipment-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-		<artifactId>status-service-interface</artifactId>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
 		<groupId>com.telecominfraproject.wlan</groupId>
+		<artifactId>tip-wlan-cloud-root-pom</artifactId>
 		<version>1.2.0-SNAPSHOT</version>
-	  </dependency>
-    
-      <dependency>
-        <artifactId>status-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-    
-      <dependency>
-        <artifactId>status-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <dependency>
-        <artifactId>cloud-event-dispatcher-empty</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
+		<relativePath>../../wlan-cloud-root</relativePath>
+	</parent>
 
-    </dependencies>
+	<artifactId>equipment-service</artifactId>
+	<name>equipment-service</name>
+	<description>Server side implementation of the service.</description>
+
+	<dependencies>
+		<dependency>
+			<artifactId>alarm-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>base-container</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>cloud-event-dispatcher-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>equipment-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<artifactId>equipment-datastore-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<artifactId>equipment-datastore-inmemory</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<artifactId>status-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>status-service-local</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<artifactId>status-datastore-inmemory</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<artifactId>cloud-event-dispatcher-empty</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
 </project>

--- a/equipment-service/src/test/java/com/telecominfraproject/wlan/equipment/controller/EquipmentControllerTest.java
+++ b/equipment-service/src/test/java/com/telecominfraproject/wlan/equipment/controller/EquipmentControllerTest.java
@@ -18,9 +18,6 @@ import com.telecominfraproject.wlan.cloudeventdispatcher.CloudEventDispatcherEmp
 import com.telecominfraproject.wlan.core.model.equipment.EquipmentType;
 import com.telecominfraproject.wlan.equipment.datastore.inmemory.EquipmentDatastoreInMemory;
 import com.telecominfraproject.wlan.equipment.models.Equipment;
-import com.telecominfraproject.wlan.status.StatusServiceLocal;
-import com.telecominfraproject.wlan.status.controller.StatusController;
-import com.telecominfraproject.wlan.status.datastore.inmemory.StatusDatastoreInMemory;
 
 /**
  * @author dtoptygin
@@ -37,10 +34,7 @@ import com.telecominfraproject.wlan.status.datastore.inmemory.StatusDatastoreInM
         EquipmentController.class,
         CloudEventDispatcherEmpty.class,
         EquipmentDatastoreInMemory.class,
-        EquipmentControllerTest.Config.class,
-        StatusServiceLocal.class,
-        StatusController.class,
-        StatusDatastoreInMemory.class
+        EquipmentControllerTest.Config.class
         })
 public class EquipmentControllerTest {
     

--- a/portal-services/pom.xml
+++ b/portal-services/pom.xml
@@ -161,20 +161,6 @@
         <version>1.2.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
-      
-      <dependency>
-        <artifactId>status-service-local</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <artifactId>status-datastore-inmemory</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-        <scope>test</scope>
-      </dependency>
-    
     </dependencies>
 </project>
 

--- a/portal-services/src/test/java/com/telecominfraproject/wlan/portal/controller/profile/ProfilePortalControllerTest.java
+++ b/portal-services/src/test/java/com/telecominfraproject/wlan/portal/controller/profile/ProfilePortalControllerTest.java
@@ -34,10 +34,6 @@ import com.telecominfraproject.wlan.profile.datastore.inmemory.ProfileDatastoreI
 import com.telecominfraproject.wlan.profile.models.Profile;
 import com.telecominfraproject.wlan.profile.models.ProfileByCustomerRequestFactory;
 import com.telecominfraproject.wlan.profile.models.ProfileType;
-import com.telecominfraproject.wlan.status.StatusServiceLocal;
-import com.telecominfraproject.wlan.status.controller.StatusController;
-import com.telecominfraproject.wlan.status.datastore.inmemory.StatusDatastoreInMemory;
-
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(profiles = {
@@ -53,10 +49,7 @@ import com.telecominfraproject.wlan.status.datastore.inmemory.StatusDatastoreInM
         ProfileDatastoreInMemory.class,
         ProfileByCustomerRequestFactory.class,
         CloudEventDispatcherEmpty.class,
-        ProfilePortalController.class,
-        StatusServiceLocal.class,
-        StatusController.class,
-        StatusDatastoreInMemory.class
+        ProfilePortalController.class
         })
 public class ProfilePortalControllerTest {
     private static AtomicLong profileIncrementer = new AtomicLong(1);

--- a/provisioning-sp/pom.xml
+++ b/provisioning-sp/pom.xml
@@ -1,97 +1,111 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.telecominfraproject.wlan</groupId>
-    <artifactId>tip-wlan-cloud-root-pom</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
-    <relativePath>../../wlan-cloud-root</relativePath>
-  </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.telecominfraproject.wlan</groupId>
+		<artifactId>tip-wlan-cloud-root-pom</artifactId>
+		<version>1.2.0-SNAPSHOT</version>
+		<relativePath>../../wlan-cloud-root</relativePath>
+	</parent>
 
-  <artifactId>provisioning-sp</artifactId>
-  <name>provisioning-sp</name>
-  <description>Stream Processors for provisioning events.</description>
-  
-    <dependencies>
-      <dependency>
-        <artifactId>base-stream-consumer</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+	<artifactId>provisioning-sp</artifactId>
+	<name>provisioning-sp</name>
+	<description>Stream Processors for provisioning events.</description>
 
-      <dependency>
-        <artifactId>service-metric-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+	<dependencies>
+		<dependency>
+			<artifactId>base-stream-consumer</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>system-event-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<dependency>
+			<artifactId>service-metric-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>base-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>routing-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>equipment-gateway-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<dependency>
+			<artifactId>system-event-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>equipment-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<dependency>
+			<artifactId>base-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>location-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<dependency>
+			<artifactId>routing-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>profile-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>client-service-interface</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <!--  models used by the application logic of the stream processor -->
-      <dependency>
-        <artifactId>equipment-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
-      
-      <dependency>
-        <artifactId>profile-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<dependency>
+			<artifactId>equipment-gateway-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-      <dependency>
-        <artifactId>location-models</artifactId>
-        <groupId>com.telecominfraproject.wlan</groupId>
-        <version>1.2.0-SNAPSHOT</version>
-      </dependency>
+		<dependency>
+			<artifactId>equipment-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
 
-    </dependencies>
+		<dependency>
+			<artifactId>location-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>profile-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>client-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>alarm-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>status-service-interface</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<!-- models used by the application logic of the stream processor -->
+		<dependency>
+			<artifactId>equipment-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>profile-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<artifactId>location-models</artifactId>
+			<groupId>com.telecominfraproject.wlan</groupId>
+			<version>1.2.0-SNAPSHOT</version>
+		</dependency>
+
+	</dependencies>
 </project>
 
 


### PR DESCRIPTION
When an AP is disconnected, an disconnected alarm is raised. When the disconnected AP is move to another customer, the alarms associated with the AP should move as well.