### PR TITLE
WIFI-3201 Equipments cusId/locId/profIds can no longer be updated to 0 with REST API

### DIFF
--- a/equipment-service-remote/src/test/java/com/telecominfraproject/wlan/equipment/EquipmentServiceRemoteTest.java
+++ b/equipment-service-remote/src/test/java/com/telecominfraproject/wlan/equipment/EquipmentServiceRemoteTest.java
@@ -83,7 +83,10 @@ public class EquipmentServiceRemoteTest extends BaseRemoteTest {
         equipment.setName("testName-"+getNextEquipmentId());
         equipment.setInventoryId("test-inv-"+getNextEquipmentId());
         equipment.setEquipmentType(EquipmentType.AP);
-
+        equipment.setLocationId(1);
+        equipment.setProfileId(1);
+        equipment.setCustomerId(1);
+        
         Equipment ret = remoteInterface.create(equipment);
         assertNotNull(ret);
         
@@ -631,6 +634,9 @@ public class EquipmentServiceRemoteTest extends BaseRemoteTest {
         equipment.setName("testName-"+getNextEquipmentId());
         equipment.setInventoryId("test-inv-"+getNextEquipmentId());
         equipment.setEquipmentType(EquipmentType.AP);
+        equipment.setCustomerId(1);
+        equipment.setLocationId(1);
+        equipment.setProfileId(1);
         equipment.setDetails(ApElementConfiguration.createWithDefaults());
 
         ElementRadioConfiguration element2dot4RadioConfig = ((ApElementConfiguration)equipment.getDetails()).getRadioMap().get(RadioType.is2dot4GHz);       

--- a/equipment-service/src/main/java/com/telecominfraproject/wlan/equipment/controller/EquipmentController.java
+++ b/equipment-service/src/main/java/com/telecominfraproject/wlan/equipment/controller/EquipmentController.java
@@ -258,7 +258,10 @@ public class EquipmentController {
         
         LOG.debug("Updating Equipment {}", equipment);
         
-        if (BaseJsonModel.hasUnsupportedValue(equipment)) {
+        if (BaseJsonModel.hasUnsupportedValue(equipment) 
+        		|| equipment.getCustomerId() == 0 
+        		|| equipment.getLocationId() == 0 
+        		|| equipment.getProfileId() == 0) {
             LOG.error("Failed to update Equipment, request contains unsupported value: {}", equipment);
             throw new DsDataValidationException("Equipment contains unsupported value");
         }


### PR DESCRIPTION
I started off by updating the hasUnsupportedValues() method in the equipment model but it caused way too many unit tests to fail and need changing so I ended up putting the check in the controller only for update to mitigate the number of changes to the unit tests.  